### PR TITLE
Bug Report #12331

### DIFF
--- a/source/appModules/itunes.py
+++ b/source/appModules/itunes.py
@@ -52,6 +52,17 @@ class AppModule(appModuleHandler.AppModule):
 			clsList.insert(0, WebKitDocument)
 		elif windowClassName=="iTunes" and obj.IAccessibleRole==oleacc.ROLE_SYSTEM_CLIENT:
 			clsList.insert(0, TopLevelClient)
+			
+			
+		############## BEGINNING ##############
+		# #12331: See documentation at the end of this file for more details. 
+		# Menu text is not announced to the user, class created below should
+		# allow functionality for this.
+		# not entirely sure if this is properly checking whether a windowClassName resides as being apart of a menu slider
+		elif windowClassName in ('iTunesList') and role in (controlTypes.ROLE_LISTITEM,controlTypes.ROLE_TREEVIEWITEM):
+			# inserting title into clsList of the correct menu heading
+			clsList.insert(0,AccessMenuTitles)
+		################# END #################
 
 class ITunesItem(NVDAObjects.IAccessible.IAccessible):
 	"""Retreaves position information encoded in the accDescription"""
@@ -110,3 +121,34 @@ class TopLevelClient(NVDAObjects.IAccessible.IAccessible):
 		if self.IAccessibleIdentity == other.IAccessibleIdentity:
 			return True
 		return super(TopLevelClient, self)._isEqual(other)
+	
+############## BEGINNING ##############
+# #12331: NVDA does not announce the names of the menus when walking with left and right
+# arrows in iTunes. This can potentially be fixed by adding a class which helps accesses the text 
+# inside of an iTunes menu box. The function added below will attempt to provide that functionality. 
+# Further additions are above which add an object of this class to the clsList in chooseNVDAObjectOverlayClasses.
+# A comment was not made on the bug report due to the issue unaffecting the user experience in any way and tight scheduling.
+# Considering I have not contributed to NVDA before, this implementation may be going off the rails. However, I think I have 
+# provided a decent foundation in solving this issue. 
+class AccessMenuTitles(NVDAObjects.IAccessible.IAccessible):
+	# function that attempts to grab title of focused object
+	def _get_name(self):
+		try:
+			title=self.title.text
+		except comtypes.COMError:
+			title=None
+		# Translators: the label for a menu in iTunes.
+		name=_("Menu Label")
+		if title:
+			name+=" (%s)"%title
+		return name
+
+	# copied from iTunesItem class
+	# ensures the title allows for an interface event
+	def _get_shouldAllowIAccessibleFocusEvent(self):
+		# These items can fire spurious focus events; e.g. when tabbing out of the Music list.
+		# The list reports that it's focused even when it isn't.
+		# Thankfully, the list items don't.
+		return self.hasFocus
+
+################# END #################


### PR DESCRIPTION
NVDA does not announce the names of the menus when walking with left and right arrows in iTunes. This can potentially be fixed by adding a class which helps accesses the text inside of an iTunes menu box. The function added below will attempt to provide that functionality. Further additions are above which add an object of this class to the clsList in chooseNVDAObjectOverlayClasses. A comment was not made on the bug report due to the issue unaffecting the user experience in any way and tight scheduling. Considering I have not contributed to NVDA before, this implementation may be going off the rails. However, I think I have provided a decent foundation in solving this issue.

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft. See https://github.com/nvaccess/nvda/wiki/Contributing
-->

### Link to issue number:
https://github.com/nvaccess/nvda/issues/12331
### Summary of the issue:
NVDA does not announce the titles of menu boxes when clicking through them using the keyboard. 
### Description of how this pull request fixes the issue:
By adding a class which helps accesses the text inside of an iTunes menu box. The class contains functions that will attempt to provide that functionality. Further additions are above which add an object of this class to the clsList in chooseNVDAObjectOverlayClasses.
### Testing strategy:
Automated tests given through NVDA's source code and local system functionality. 
### Known issues with pull request:
No known issues with the automated tests. Local testing of NVDA seemed to now read the titles of menu boxes as well. However, I am not sure if my code incorporated the fix, or if simply restarting my computer and rebuilding NVDA accomplished the goal.
### Change log entries:
New features: Menu titles are announced back to the user in iTunes
Changes: Added a class that gets added to "clsList" which is the structure that handles announcing text
Bug fixes: Bug report #12331
For Developers: I am a beginning developer with NVDA and believe my implementation may be going off the rails. However, this solution could incorporate some foundation in another solution, or further prove the bug does not exist.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review and confirm you have considered the following items.
Mark items you have considered by checking them.
You can do this when editing the Pull request description with an x: `[ ]` becomes `[x]`.
You can also check the checkboxes after the PR is created.
-->

- [ x] Pull Request description is up to date.
- [ x] Unit tests.
- [ x] System (end to end) tests.
- [ ] Manual tests.
- [ x] User Documentation.
- [ x] Change log entry.
- [ ] Context sensitive help for GUI changes.
